### PR TITLE
Fix the `prefer_standard` setting

### DIFF
--- a/prefer-standard.py
+++ b/prefer-standard.py
@@ -10,9 +10,9 @@ class StandardRBPreferStandardListener(sublime_plugin.EventListener):
         self.rubocop_installed = 'SublimeLinter-rubocop' in sys.modules
 
         plugin_settings = sublime.load_settings('SublimeLinter.sublime-settings')
-        linter_settings = plugin_settings.get('linters')
-        rubocop_settings = linter_settings.get('rubocop')
-        standardrb_settings = linter_settings.get('standardrb')
+        linter_settings = plugin_settings.get('linters', {})
+        rubocop_settings = linter_settings.get('rubocop', {})
+        standardrb_settings = linter_settings.get('standardrb', {})
 
         self.rubocop_disabled = rubocop_settings.get('disable')
         self.standard_disabled = standardrb_settings.get('disable')

--- a/prefer-standard.py
+++ b/prefer-standard.py
@@ -75,7 +75,12 @@ class StandardRBPreferStandardListener(sublime_plugin.EventListener):
             return None
 
     def get_closest_config_file_path(self):
-        project_folders = self.view.window().folders()
+        window = self.view.window()
+
+        if not window:
+            return None
+
+        project_folders = window.folders()
 
         if not project_folders:
             return None

--- a/prefer-standard.py
+++ b/prefer-standard.py
@@ -1,5 +1,6 @@
 import sys
 import os
+import sublime
 import sublime_plugin
 
 
@@ -8,14 +9,14 @@ class StandardRBPreferStandardListener(sublime_plugin.EventListener):
         self.view = view
         self.rubocop_installed = 'SublimeLinter-rubocop' in sys.modules
 
-        key = 'SublimeLinter.linters.rubocop.disable'
-        self.rubocop_disabled = view.settings().get(key)
+        plugin_settings = sublime.load_settings('SublimeLinter.sublime-settings')
+        linter_settings = plugin_settings.get('linters')
+        rubocop_settings = linter_settings.get('rubocop')
+        standardrb_settings = linter_settings.get('standardrb')
 
-        key = 'SublimeLinter.linters.standardrb.disable'
-        self.standard_disabled = view.settings().get(key)
-
-        key = 'SublimeLinter.linters.standardrb.prefer_standard'
-        self.should_prefer_standard = view.settings().get(key, False)
+        self.rubocop_disabled = rubocop_settings.get('disable')
+        self.standard_disabled = standardrb_settings.get('disable')
+        self.should_prefer_standard = standardrb_settings.get('prefer_standard', False)
 
         # Don't proceed if we shouldn't be selecting
         # a linter in the first place


### PR DESCRIPTION
The `standardrb` plugin for SublimeLinter has a nifty linter setting called [`prefer_standard`](https://github.com/testdouble/SublimeLinter-contrib-standardrb?tab=readme-ov-file#option-3-using-the-prefer_standard-setting-to-check-for-config-files), that will choose to use `standardrb` or `rubocop` based on the presence of a standardrb.yml file. It’s very useful when switching between trackpipe and services, and between newer standardrbised services and older ones.

But [it doesn’t work](https://github.com/testdouble/SublimeLinter-contrib-standardrb/issues/6). It tries to get the SublimeLinter settings in a way that doesn’t seem to be supported any more:
```python
view.settings().get('SublimeLinter.linters.rubocop.disable')
```

I dug around and figured out that we can get the SublimeLinter settings like so instead:
```python
sublime.load_settings('SublimeLinter.sublime-settings')
```

The docs suggest that `load_settings` does some cacheing, and it doesn’t seem to affect performance at all in my testing (this whole function is run in a background thread anyway).

I have no idea how Python formatting is supposed to look (ironically), so I’m mostly looking for a basic review of the Python. If it works for us I might submit a PR and try get the fix into the ST package manager.